### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Features caching, so repeated loadings to the same url result in only one reques
 
 ### CDN
 
-``<script src="//cdn.jsdelivr.net/audiofx/latest/AudioFX.min.js"></script>``
+``<script src="//cdn.jsdelivr.net/npm/audiofx@latest/dist/AudioFX.min.js"></script>``
 
 ### Bower
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/audiofx.

Feel free to ping me if you have any questions regarding this change.